### PR TITLE
Clarifications to Distcc usage

### DIFF
--- a/Distcc_Cross-Compiling.md
+++ b/Distcc_Cross-Compiling.md
@@ -18,7 +18,7 @@ It is *highly recommended* to use these tarballs as they have been thoroughly te
 * [ARMv7l hard](/builder/xtools/x-tools7h.tar.xz) (58766cfb988135f761d9f4c2c0d5c4e4)
 * [ARMv8](/builder/xtools/x-tools8.tar.xz) (87e0796ac697c9dceb3e83a51b51113c)
 
-If you want to save yourself time and configuration, see [WarheadsSE's distccd-alarm](https://github.com/WarheadsSE/PKGs/tree/master/distccd-alarm) package. This will generate 3 packages (one for each architecture), and contains configuration and systemd service units for each. It is for x86_64 only, like these toolchain tarballs.
+If you want to save yourself time and configuration, see [WarheadsSE's distccd-alarm](https://github.com/WarheadsSE/PKGs/tree/master/distccd-alarm) package. This will generate 4 packages (one for each architecture), and contains configuration and systemd service units for each. It is for x86_64 only, like these toolchain tarballs.
 
 ## Install crosstool-ng
 This process is very automated, courtesy of [crosstool-ng](http://crosstool-ng.org). As a normal user (<b>not root!</b>), clone revision e1d494a of the git repository into a directory called "cross" in your home directory. Enter the source directory and configure with a prefix for the "cross" directory, make, and make install.  If you are missing any pre-requisites, the configure script will let you know what they are.

--- a/Distributed_Compiling.md
+++ b/Distributed_Compiling.md
@@ -13,7 +13,7 @@ For the purposes of this example, all of the hosts are in the local network of 1
 
 Additionally, this example assumes that you are starting compiles from one specific device (master), which is sending out to the other device(s) (client).  If you want to compile from any device, simply apply the client configuration to the master device, and the master device configuration to the client device(s).
 
-If you want to use the master device to compile as well, apply the client configuration to it.
+If you want to use the master device to compile as well, apply the client configuration to it. It is only suggest to use the master if all slaves are the same architecture as the master (ARM).
 
 ## Configuration: Master Device
 This is what you run on the ARM device you'll be running "makepkg" from and using to coordinate builds.


### PR DESCRIPTION
- Add a clarification to `Distributed_Compiling` about only using the master if the CPU architectures match.
- Update `Distcc_Cross-Compiling` to show the 4 packages generated by `distccd-alarm` from @WarheadsSE
