### PR TITLE
add BeagleBone Black (Wireless) and Green (Wireless) pages

### DIFF
--- a/BeagleBone_Black.md
+++ b/BeagleBone_Black.md
@@ -1,0 +1,17 @@
+## USB network interface
+In order use the USB network interface you need to load the USB gadget kernel module:
+
+```bash
+sudo modprobe g_ether
+```
+
+Or, if you want to load this module every time you boot:
+
+```bash
+echo g_ether > /etc/modules-load.d/g_ether.conf
+```
+
+Then, the interface should be visible as `usb0`.
+
+## IO
+There is an extensive BeagleBone IO [python library](https://github.com/adafruit/adafruit-beaglebone-io-python) from Adafruit.

--- a/BeagleBone_Black_Wireless.md
+++ b/BeagleBone_Black_Wireless.md
@@ -1,0 +1,1 @@
+BeagleBone_Black.md

--- a/BeagleBone_Green.md
+++ b/BeagleBone_Green.md
@@ -1,0 +1,1 @@
+BeagleBone_Black.md

--- a/BeagleBone_Green_Wireless.md
+++ b/BeagleBone_Green_Wireless.md
@@ -1,0 +1,1 @@
+BeagleBone_Black.md

--- a/Platforms.md
+++ b/Platforms.md
@@ -18,6 +18,11 @@ These are pages containing additional information for running Arch Linux ARM on 
         * [[ODROID-U2]]
         * [[ODROID-U3]]
         * [[Samsung Chromebook]]
+    * TI
+        * [[BeagleBone Black]]
+        * [[BeagleBone Black Wireless]]
+        * [[BeagleBone Green]]
+        * [[BeagleBone Green Wireless]]
 * ARMv8
     * Amlogic
         * [[ODROID-C2]]


### PR DESCRIPTION
Add information about enabling the USB network device and about a known
kernel bug affecting the cape manager.