### PR TITLE
Update Rock64.md with a hint at how to enable audio

### DIFF
--- a/Rock64.md
+++ b/Rock64.md
@@ -3,3 +3,10 @@ UART is accessible on the Pi-2 bus (same pins as on a Raspberry Pi), using a bau
 
 ## MAC Address
 The MAC address for the system is configurable in /boot/boot.txt.  Use spaces instead of colons between each octet.  After making changes, run the *mkscr* script from within /boot.
+
+## Audio
+Audio can be enabled by installing `dtc` and issuing
+```
+fdtput -t s /boot/dtbs/rockchip/rk3328-rock64.dtb /analog-sound status okay
+reboot
+```


### PR DESCRIPTION
I    tested the solution proposed in https://forum.manjaro.org/t/rock64-no-audio-output/56032 and it works for linux-image-5.11.