### PR TITLE
Add instruction on how to set up WiFi before first run

### DIFF
--- a/How-to.md
+++ b/How-to.md
@@ -1,0 +1,3 @@
+Some step-by-step help to get started:
+
+* [[Offline_wifi_setup]]: Set up WiFi access before running your device

--- a/Offline_wifi_setup.md
+++ b/Offline_wifi_setup.md
@@ -1,0 +1,16 @@
+To quickly set up the WiFi before booting your device, you can follow this procedure in the **root/** directory of your installation (from your computer):
+
+Copy the example configuration for a WPA connection for netctl:
+
+    cp etc/netctl/examples/wireless-wpa etc/netctl/wireless-wpa
+
+Edit the SSID and key for your access point:
+
+    sed -i "s/ESSID=.*/ESSID='MySSID'/" etc/netctl/wireless-wpa
+    sed -i "s/Key=.*/Key='MyKey'/" etc/netctl/wireless-wpa
+
+Enable the netctl-auto service (the first argument starting with `/` is on purpose):
+
+    ln -s /usr/lib/systemd/system/netctl-auto@.service etc/systemd/system/multi-user.target.wants/netctl-auto@wlan0.service
+
+Now you can start your device and you should get automatically connected to your WiFi network.

--- a/Wiki.md
+++ b/Wiki.md
@@ -4,5 +4,6 @@ Categories:
 
 * [[Developers]] - Resources for building packages on Arch Linux ARM.
 * [[Platforms]] - Additional information on supported platforms
+* [[How-to]] - Some step-by-step help to get started
 
 To contribute to this wiki, see the [[Contributing]] page. Content is available under the [GNU Free Documentation License 1.3 or later](http://www.gnu.org/copyleft/fdl.html) unless otherwise noted.  


### PR DESCRIPTION
Add a new entry in the quite empty "Wiki" index to a new list of how-to, with a first entry on how to setup WiFi access before first run