### PR TITLE
Raspberry Pi watchdog updates and serial console notes

### DIFF
--- a/Raspberry_Pi.md
+++ b/Raspberry_Pi.md
@@ -166,14 +166,16 @@ Where `<id>` is:
 
 ### Watchdog
 BCM2708 has a hardware watchdog which can be utilized by enabling the
-`bcm2708_wdog` kernel module.  
+`bcm2708_wdog` kernel module, `bcm2709_wdog` for the Pi 2, or `bcm2835_wdt`
+for the Pi 3.  In most cases these modules will load automatically.
 
-For proper operation the watchdog daemon also has to be installed, configured
-(by uncommenting the "watchdog-device" line in `/etc/watchdog.conf`) and
-enabled.  
+To activate the watchdog, set the `RuntimeWatchdogSec` value in
+`/etc/systemd/system.conf`.  The largest permitted value is `15s` due to
+hardware limitations.
 
-This should also apply for Raspberry Pi 2 by using the `bcm2709_wdog` module
-and Raspberry Pi 3 by using the `bcm2835_wdt` module.
+The watchdog service is part of systemd, so no further configuration needs to
+be done.  `/etc/watchdog.conf` is no longer required as it was in the past, and
+separate `systemctl` steps to enable and activate the service no longer apply.
 
 ## Hardware Random Number Generator
 Arch Linux ARM for the Raspberry Pi had the `bcm2708-rng` module set to load at

--- a/Raspberry_Pi.md
+++ b/Raspberry_Pi.md
@@ -260,6 +260,12 @@ To use the GPIO/SPI pins as a regular non-root user (in group `tty`), add the fo
     SUBSYSTEM=="gpio", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="/bin/sh -c 'chown root:tty /sys/class/gpio/export /sys/class/gpio/unexport ; chmod 220 /sys/class/gpio/export /sys/class/gpio/unexport'"
     SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown root:tty /sys%p/active_low /sys%p/direction /sys%p/edge /sys%p/value ; chmod 660 /sys%p/active_low /sys%p/direction /sys%p/edge /sys%p/value'"
 
+### Serial Console
+
+Adding `console=ttyAMA0,115200` to the kernel command line will enable it from
+the kernel's perspective.  On some models, the serial UART conflicts with the
+Bluetooth UART, so disabling Bluetooth with `dtoverlay=disable-bt` in
+`config.txt` may be required in order to get the serial console working.
 
 ## See Also
 


### PR DESCRIPTION
For a while now (some years), systemd has natively supported the watchdog so this update to the instructions explains how to set it up in preference to the old way.

This also includes some notes on how to get the serial console working.