### PR TITLE
[Raspberry_Pi.md] removes the entire hwrng block

### DIFF
--- a/Raspberry_Pi.md
+++ b/Raspberry_Pi.md
@@ -175,32 +175,6 @@ enabled.
 This should also apply for Raspberry Pi 2 by using the `bcm2709_wdog` module
 and Raspberry Pi 3 by using the `bcm2835_wdt` module.
 
-## Hardware Random Number Generator
-Arch Linux ARM for the Raspberry Pi had the `bcm2708-rng` module set to load at
-boot; starting with kernel 4.4.7 the `bcm2835_rng` module replaces the
-former on Raspberry Pi 2 and Raspberry Pi 3 units.  
-
-Install `rng-tools` and
-tell the Hardware RNG Entropy Gatherer Daemon (`rngd`) where to find the hardware
-random number generator.  This can be done by editing `/etc/conf.d/rngd`:
-
-    RNGD_OPTS="-o /dev/random -r /dev/hwrng" 
-
-and enabling and starting the `rngd` service.  
-
-If `haveged` is running, it should be stopped and disabled, as it might
-compete with `rngd` and is only preferred when there is no hardware random number
-generator available.  
-
-Once completed, this change ensures that data from the
-hardware random number generator is fed into the kernel's entropy pool at
-`/dev/random`. To check the available entropy, run: 
-
-    # cat /proc/sys/kernel/random/entropy_avail 
-    
-The number it reports should be around 3000, whereas before setting up rngd it
-would have been closer to 1000.
-
 ## I/O Pins
 ### GPIO
 To be able to use the GPIO pins from Python, use the RPi.GPIO library. 


### PR DESCRIPTION
Reflecting kernel changes from earlier this year, poolsize nowadays is 256, kernel nowadays should be able to handle hwrng without rngd/haveged.
Can't test on every RPI but at least true on rpi4 aarch64 w/rpi kernel.
See https://github.com/nhorman/rng-tools/issues/167#issuecomment-1099812490